### PR TITLE
Switch to HTTPS URL

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,6 @@
 Pkg.add("Iterators")
 Pkg.add("Polynomials")
 Pkg.add("Cubature")
-Pkg.clone("git@github.com:mortenpi/Orthopolys.jl.git")
+
+# The Orthopolys packages is not in the package repo
+Pkg.clone("https://github.com/mortenpi/Orthopolys.jl.git")


### PR DESCRIPTION
According to
https://github.com/JuliaLang/PkgDev.jl/issues/7#issuecomment-148237785

> The git protocol is simply not supported with Pkg on libgit2.

So, for the nightlies we need to switch to HTTPS.
